### PR TITLE
Add support for x86_64-fortanix-unknown-sgx target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,6 +286,9 @@ libc = { version = "0.2.34" }
 [target.'cfg(any(target_os = "redox", all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies]
 lazy_static = "1.2"
 
+[target.'cfg(target_env = "sgx")'.dependencies]
+rdrand = "0.3.0"
+
 # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
 [build-dependencies]
 # we do not use the gcc parallel feature because we do the


### PR DESCRIPTION
rdrand dependency in Cargo.toml will be eventually fetched from its original repo master branch once sgx support for rdrand has landed